### PR TITLE
Fix error when opening project with spaces

### DIFF
--- a/Editor/VimExternalEditor.cs
+++ b/Editor/VimExternalEditor.cs
@@ -394,11 +394,11 @@ namespace Vim.Editor
                     break;
 
                 case SetPathBehaviour.ToProjectPath:
-                    path = $"+\"set path+={Application.dataPath}/**\"";
+                    path = $"+\"set path+=\\\"{Application.dataPath}/**\\\"\"";
                     break;
 
                 case SetPathBehaviour.ToScriptPath:
-                    path = $"+\"set path+={Application.dataPath}/Scripts/**\"";
+                    path = $"+\"set path+=\\\"{Application.dataPath}/Scripts/**\\\"\"";
                     break;
             }
 


### PR DESCRIPTION
When I opened one of my projects containing a space in the path gvim didn't want to start.
All I did was adding double-quotes around Application.dataPath and it works now !