### PR TITLE
Allow editing multiple projects

### DIFF
--- a/Editor/VimExternalEditor.cs
+++ b/Editor/VimExternalEditor.cs
@@ -125,7 +125,7 @@ namespace Vim.Editor
         const string k_servername_key = "vimcode_servername";
         static string GetServerName()
         {
-            return EditorPrefs.GetString(k_servername_key, "Unity");
+            return EditorPrefs.GetString(k_servername_key, $"Unity ({PlayerSettings.productGUID})");
         }
 
         const string k_force_foreground_key = "vimcode_force_foreground";

--- a/Editor/VimExternalEditor.cs
+++ b/Editor/VimExternalEditor.cs
@@ -402,7 +402,7 @@ namespace Vim.Editor
                     break;
             }
 
-            start_info.Arguments = $"--servername {GetServerName()} --remote-silent +\"call cursor({line},{column})\" {GetExtraCommands()} {path} \"{file}\"";
+            start_info.Arguments = $"--servername \"{GetServerName()}\" --remote-silent +\"call cursor({line},{column})\" {GetExtraCommands()} {path} \"{file}\"";
 
             //~ Debug.Log($"[VimExternalEditor] Launching {start_info.FileName} {start_info.Arguments}");
 


### PR DESCRIPTION
If we open gvim for more than one project they will use the same server (Unity by default) resulting in unexpected behaviour
We can change it manually of course, but I thought it was a good idea to add the project GUID in the generated server name to ensure each instance is unique by default.

One drawback is that the window name is long and not really "aesthetic" (it shows something like `Test.cs (D:\GameDev\[...]) - UNITY (909CF5643-V9RJV03C4[...])`) so I could understand if this PR is not merged

I also surrounded `{GetServerName()}` with double-quote to allow a server name with spaces